### PR TITLE
added instructions for extra steps to get sops working on a mac

### DIFF
--- a/02-getting-started.md
+++ b/02-getting-started.md
@@ -247,17 +247,6 @@ Please save your public key and add it to .sops.yaml:
 # public key: age1vhctyw5e38fr8s6dmaygltsl0rtd6zd34tp88za4purrrcn7vqdq3hf0lw
 ```
 
-**Extra step for Mac users only:**
-
-Mac expects the key file to be in a different location than where it gets generated. Move your key to the location Mac wants it to be at with 
-
-```bash
-# do this only if you're on a mac! 
-mkdir -p ~/Library/Application\ Support/sops/age 
-mv ~/.config/sops/age/keys.txt ~/Library/Application\ Support/sops/age/keys.txt
-```
-
-
 **Important:**
 
 - Save the public key displayed in the terminal


### PR DESCRIPTION
Several Mac users have run into issues setting up sops keys. The issue seems to boil down to Mac generating the key into ~/.config/sops/age/keys.txt but looking for it in ~/Library/Application Support/sops/age/keys.txt . 

This fix proposes adding a step to the getting started document where a Mac user will move their keys.txt to the location where the system knows to look for it before proceeding with the tutorial. 